### PR TITLE
feat: configure global object mapper

### DIFF
--- a/src/main/kotlin/com/babymonitor/config/JacksonConfig.kt
+++ b/src/main/kotlin/com/babymonitor/config/JacksonConfig.kt
@@ -1,0 +1,22 @@
+package com.babymonitor.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+
+@Configuration
+class JacksonConfig {
+
+    @Bean
+    @Primary
+    fun objectMapper(): ObjectMapper {
+        return ObjectMapper()
+            .registerKotlinModule()
+            .registerModule(JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    }
+}


### PR DESCRIPTION
## Summary
- configure Jackson to handle Kotlin and Java Time

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.3.2'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898c8224c88832ca987d282cf02d44e